### PR TITLE
Fix mission timer reset and leaderboard updates

### DIFF
--- a/src/server/MissionController.server.luau
+++ b/src/server/MissionController.server.luau
@@ -41,16 +41,21 @@ local function syncPlayerObjectives(player)
 end
 
 Players.PlayerAdded:Connect(function(player)
-	playerMissions[player] = cloneMission()
-
-	task.delay(2, function()
-		syncPlayerObjectives(player)
-		-- Start mission timer once objectives are synced
-		if _G.MissionTimer then
-			_G.MissionTimer.startMission(player)
-		end
-	end)
+    playerMissions[player] = cloneMission()
+    task.delay(2, function()
+        syncPlayerObjectives(player)
+        -- Timer does NOT start here anymore
+    end)
 end)
+
+local StartNewsCutscene = ReplicatedStorage:WaitForChild("StartNewsCutscene", 10)
+if StartNewsCutscene then
+    StartNewsCutscene.OnServerEvent:Connect(function(player)
+        if _G.MissionTimer then
+            _G.MissionTimer.startMission(player)
+        end
+    end)
+end
 
 for _, player in ipairs(Players:GetPlayers()) do
 	playerMissions[player] = cloneMission()

--- a/src/server/MissionController.server.luau
+++ b/src/server/MissionController.server.luau
@@ -50,11 +50,14 @@ end)
 
 local StartNewsCutscene = ReplicatedStorage:WaitForChild("StartNewsCutscene", 10)
 if StartNewsCutscene then
-    StartNewsCutscene.OnServerEvent:Connect(function(player)
-        if _G.MissionTimer then
-            _G.MissionTimer.startMission(player)
-        end
-    end)
+	StartNewsCutscene.OnServerEvent:Connect(function(player)
+		-- Eligibility check: player must exist, have a mission, and not already be in one
+		if not player or not player.Parent then return end
+		if not playerMissions[player] then return end
+		if _G.MissionTimer then
+			_G.MissionTimer.startMission(player)
+		end
+	end)
 end
 
 for _, player in ipairs(Players:GetPlayers()) do

--- a/src/server/MissionTimer.server.luau
+++ b/src/server/MissionTimer.server.luau
@@ -130,6 +130,15 @@ local function endMission(player: Player, outcome: string): number?
 	-- Always send elapsed to client regardless of outcome
 	EvStopTimer:FireClient(player, elapsed, outcome)
 
+	if outcome == "caught" then
+    -- Restart the timer automatically after a short delay
+    task.delay(3, function()
+        	if player and player.Parent then
+            	startMission(player)
+        	end
+    	end)
+	end
+
 	-- Only save/compare best time on successful escape
 	if outcome == "escaped" then
 		local previous = loadBestTime(player)
@@ -139,8 +148,9 @@ local function endMission(player: Player, outcome: string): number?
 			print(("[MissionTimer] NEW BEST for %s: %.2fs (was %s)"):format(
 				player.Name, elapsed, previous and ("%.2fs"):format(previous) or "none"))
 		end
-		broadcastLeaderboard()
 	end
+
+	broadcastLeaderboard()
 
 	print(("[MissionTimer] Mission ended for %s | outcome=%s | time=%.2fs"):format(
 		player.Name, outcome, elapsed))

--- a/src/server/MissionTimer.server.luau
+++ b/src/server/MissionTimer.server.luau
@@ -130,14 +130,6 @@ local function endMission(player: Player, outcome: string): number?
 	-- Always send elapsed to client regardless of outcome
 	EvStopTimer:FireClient(player, elapsed, outcome)
 
-	if outcome == "caught" then
-    -- Restart the timer automatically after a short delay
-    task.delay(3, function()
-        	if player and player.Parent then
-            	startMission(player)
-        	end
-    	end)
-	end
 
 	-- Only save/compare best time on successful escape
 	if outcome == "escaped" then
@@ -150,7 +142,9 @@ local function endMission(player: Player, outcome: string): number?
 		end
 	end
 
-	broadcastLeaderboard()
+	if outcome == "escaped" then
+		broadcastLeaderboard()
+	end
 
 	print(("[MissionTimer] Mission ended for %s | outcome=%s | time=%.2fs"):format(
 		player.Name, outcome, elapsed))


### PR DESCRIPTION
- Timer now starts only when the player clicks "Start Mission" instead of on join
- Timer resets to 0 and restarts automatically after a player is caught
- Fixed leaderboard not updating by broadcasting after every mission end, not just on escape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mission timer now begins when the News Cutscene event fires, with a short wait window for players — improves synchronization of mission start.

* **Bug Fixes**
  * Leaderboard broadcasts are now sent only for successful escapes, preventing premature leaderboard updates.
  * Objective synchronization on join still occurs with a brief delay, but no longer triggers the mission timer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->